### PR TITLE
(feat): Change optimizer_type text field to dropdown

### DIFF
--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -1417,10 +1417,10 @@ with gr.Blocks(theme=theme, css=custom_log_box_css) as demo:
                 
         gr.Markdown("#### Optimizer Parameters")
         with gr.Row():
-            optimizer_type = gr.Textbox(
+            optimizer_type = gr.Dropdown(
                 label="Optimizer Type",
+                choices=['adamw', 'adamw8bit', 'adamw_optimi', 'stableadamw', 'sgd', 'adamw8bitKahan', 'offload'],
                 value="adamw_optimi",
-                info="Type of optimizer (adamw, adamw8bit, adamw_optimi, stableadamw, sgd, adamw8bitKahan, offload))"
             )
             betas = gr.Textbox(
                 label="Betas",


### PR DESCRIPTION
According to the train.py there are currently 7 available optimizers:
```
if optim_type == 'adamw':
   # TODO: fix this. I'm getting "fatal error: cuda_runtime.h: No such file or directory"
   # when Deepspeed tries to build the fused Adam extension.
   # klass = deepspeed.ops.adam.FusedAdam
    klass = torch.optim.AdamW
elif optim_type == 'adamw8bit':
    import bitsandbytes
    klass = bitsandbytes.optim.AdamW8bit
elif optim_type == 'adamw_optimi':
    import optimi
    klass = optimi.AdamW
elif optim_type == 'stableadamw':
    import optimi
    klass = optimi.StableAdamW
elif optim_type == 'sgd':
    klass = torch.optim.SGD
elif optim_type == 'adamw8bitkahan':
    from optimizers import adamw_8bit
    klass = adamw_8bit.AdamW8bitKahan
elif optim_type == 'offload':
    from torchao.prototype.low_bit_optim import CPUOffloadOptimizer
    klass = CPUOffloadOptimizer
    args.append(torch.optim.AdamW)
    kwargs['fused'] = True
else:
    raise NotImplementedError(optim_type)
```
I've previously ran into the issue of writing something wrong into the optimizer and typo's might happen.
Since there's only these 7 available optimizers it'd probably be helpful to some and time-saving to others if the optimizer selection was a dropdown instead of a text field.

So this was added:

- turned optimizer type text-field into a dropdown selection